### PR TITLE
Migrate tests from slushy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     </parent>
 
     <artifactId>kemitix-trello</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
 
     <properties>
         <tiles-maven-plugin.version>2.18</tiles-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,8 @@
         <trello-java-wrapper.version>0.14</trello-java-wrapper.version>
         <lombok.version>1.18.16</lombok.version>
         <camel-api.version>3.6.0</camel-api.version>
+        <junit.version>5.6.1</junit.version>
+        <assertj.version>3.18.1</assertj.version>
     </properties>
 
     <dependencies>
@@ -55,6 +57,20 @@
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <version>2.0.2</version>
             <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj.version}</version>
+            <scope>test</scope>
         </dependency>
 
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,11 @@
                         <tile>net.kemitix.tiles:maven-plugins:${kemitix-tiles.version}</tile>
                         <tile>net.kemitix.tiles:compiler-jdk-lts:${kemitix-tiles.version}</tile>
                         <tile>net.kemitix.tiles:testing:${kemitix-tiles.version}</tile>
+                        <!--<tile>net.kemitix.tiles:pmd:${kemitix-tiles.version}</tile>-->
+                        <!--<tile>net.kemitix.tiles:spotbugs:${kemitix-tiles.version}</tile>-->
+                        <!--<tile>net.kemitix.tiles:coverage:${kemitix-tiles.version}</tile>-->
+                        <!--<tile>net.kemitix.tiles:pitest:${kemitix-tiles.version}</tile>-->
+                        <!--<tile>net.kemitix.tiles:pmd-strict:${kemitix-tiles.version}</tile>-->
                     </tiles>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,7 @@
                     <tiles>
                         <tile>net.kemitix.tiles:maven-plugins:${kemitix-tiles.version}</tile>
                         <tile>net.kemitix.tiles:compiler-jdk-lts:${kemitix-tiles.version}</tile>
+                        <tile>net.kemitix.tiles:testing:${kemitix-tiles.version}</tile>
                     </tiles>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,8 @@
         <camel-api.version>3.6.0</camel-api.version>
         <junit.version>5.6.1</junit.version>
         <assertj.version>3.18.1</assertj.version>
+        <jakarta.enterprise.cdi-api.version>2.0.2
+        </jakarta.enterprise.cdi-api.version>
     </properties>
 
     <dependencies>
@@ -38,16 +40,6 @@
             <version>${trello-java-wrapper.version}</version>
         </dependency>
         <dependency>
-            <groupId>javax.inject</groupId>
-            <artifactId>javax.inject</artifactId>
-            <version>1</version>
-        </dependency>
-        <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
-            <version>1.3.2</version>
-        </dependency>
-        <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-api</artifactId>
             <version>${camel-api.version}</version>
@@ -55,8 +47,7 @@
         <dependency>
             <groupId>jakarta.enterprise</groupId>
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
-            <version>2.0.2</version>
-            <scope>compile</scope>
+            <version>${jakarta.enterprise.cdi-api.version}</version>
         </dependency>
 
         <dependency>

--- a/src/test/java/net/kemitix/trello/TrelloCardTest.java
+++ b/src/test/java/net/kemitix/trello/TrelloCardTest.java
@@ -1,0 +1,56 @@
+package net.kemitix.trello;
+
+import com.julienvey.trello.Trello;
+import com.julienvey.trello.domain.Badges;
+import com.julienvey.trello.domain.Card;
+import com.julienvey.trello.domain.Label;
+import org.assertj.core.api.WithAssertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Date;
+import java.util.List;
+
+public class TrelloCardTest
+        implements WithAssertions {
+
+    @Test
+    void convertCardToTrelloCard() {
+        //given
+        Card card = getCard();
+        Trello trello = null;
+        //when
+        TrelloCard trelloCard = TrelloCard.from(card, trello);
+        //then
+        assertThat((Card) trelloCard)
+                .usingRecursiveComparison()
+                .ignoringFields("dueComplete")
+                .isEqualTo(card);
+    }
+
+    private Card getCard() {
+        Card c = new Card();
+        c.setId("id");
+        c.setName("name");
+        c.setIdList("idList");
+        c.setDesc("desc");
+        c.setUrl("url");
+        c.setDue(new Date());
+        c.setIdMembers(List.of("idMember"));
+        c.setLabels(List.of(new Label()));
+        c.setBadges(new Badges());
+        c.setCheckItemStates(List.of(new Card.CardCheckItem()));
+        c.setClosed(true);
+        c.setDateLastActivity(new Date());
+        c.setIdBoard("idBoard");
+        c.setIdChecklists(List.of("idChecklists"));
+        c.setIdMembersVoted(List.of("idMembersVoted"));
+        c.setIdShort("idShort");
+        c.setIdAttachmentCover("idAttachmentCover");
+        c.setManualCoverAttachment(true);
+        c.setPos(42);
+        c.setShortLink("shortLink");
+        c.setShortUrl("shortUrl");
+        c.setSubscribed(true);
+        return c;
+    }
+}


### PR DESCRIPTION
The test class hadn’t been copied over to this project. 

----

Adds test dependencies, junit and assertj. Enable running tests.
Also cleans up dependencies on javax/jakarta apis.

#