### PR TITLE
Fix Javadoc warnings

### DIFF
--- a/src/main/java/net/kemitix/trello/TrelloConfig.java
+++ b/src/main/java/net/kemitix/trello/TrelloConfig.java
@@ -6,6 +6,8 @@ public interface TrelloConfig {
      * The Trello Developer API Key.
      *
      * <p>https://trello.com/app-key</p>
+     *
+     * @return The Trello Developer API Key
      */
     String getTrelloKey();
 
@@ -13,16 +15,22 @@ public interface TrelloConfig {
      * The Trello Developer API Key Token.
      *
      * <p>https://trello.com/app-key</p>
+     *
+     * @return The Trello Developer API Key Token
      */
     String getTrelloSecret();
 
     /**
      * The name of the user with access to the Trello Slush Pile Board.
+     *
+     * @return The Trello Username
      */
     String getUserName();
 
     /**
      * The trello board containing the Slush Pile.
+     *
+     * @return The Trello Board Name
      */
     String getBoardName();
 
@@ -30,6 +38,8 @@ public interface TrelloConfig {
      * The email address to send submission attachments to.
      *
      * <p>e.g. the kindle address</p>
+     *
+     * @return The Sender Email Address
      */
     String getSender();
 
@@ -37,11 +47,15 @@ public interface TrelloConfig {
      * The email address to send emails from.
      *
      * <p>If sending to Kindle, then ensure this address is listed as a valid sender.</p>
+     *
+     * @return The Reader Email address
      */
     String getReader();
 
     /**
      * The URL of the Webhook to register with services.
+     *
+     * @return The Webhook URL
      */
     String getWebhook();
 


### PR DESCRIPTION
```
Warning:  Javadoc Warnings
Warning:  /home/runner/work/***-trello/***-trello/src/main/java/net/***/trello/TrelloConfig.java:10: warning: no @return
Warning:  String getTrelloKey();
Warning:  ^
Warning:  /home/runner/work/***-trello/***-trello/src/main/java/net/***/trello/TrelloConfig.java:17: warning: no @return
Warning:  String getTrelloSecret();
Warning:  ^
Warning:  /home/runner/work/***-trello/***-trello/src/main/java/net/***/trello/TrelloConfig.java:22: warning: no @return
Warning:  String getUserName();
Warning:  ^
Warning:  /home/runner/work/***-trello/***-trello/src/main/java/net/***/trello/TrelloConfig.java:27: warning: no @return
Warning:  String getBoardName();
Warning:  ^
Warning:  /home/runner/work/***-trello/***-trello/src/main/java/net/***/trello/TrelloConfig.java:34: warning: no @return
Warning:  String getSender();
Warning:  ^
Warning:  /home/runner/work/***-trello/***-trello/src/main/java/net/***/trello/TrelloConfig.java:41: warning: no @return
Warning:  String getReader();
Warning:  ^
Warning:  /home/runner/work/***-trello/***-trello/src/main/java/net/***/trello/TrelloConfig.java:46: warning: no @return
Warning:  String getWebhook();
Warning:  ^
```